### PR TITLE
[Feat/#20] 공통 컴포넌트 Tag 구현

### DIFF
--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/IconTag.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/IconTag.kt
@@ -1,0 +1,162 @@
+package com.spoony.spoony.core.designsystem.component.tag
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import com.spoony.spoony.R
+import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
+import com.spoony.spoony.core.designsystem.type.IconTagColor
+import com.spoony.spoony.core.designsystem.type.TagSize
+
+@Composable
+fun IconTag(
+    text: String,
+    tagSize: TagSize,
+    tagColor: IconTagColor,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    icon: (@Composable (Color) -> Unit)? = null
+) {
+    val spoonTypography = SpoonyAndroidTheme.typography
+    val spoonyColor = SpoonyAndroidTheme.colors
+    val textStyle = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> spoonTypography.body2sb
+            TagSize.Small -> spoonTypography.caption1m
+        }
+    }
+    val backgroundBrush = remember(tagSize, tagColor) {
+        when (tagSize) {
+            TagSize.Large -> when (tagColor) {
+                IconTagColor.Black -> Brush.linearGradient(
+                    colors = listOf(
+                        spoonyColor.gray800,
+                        spoonyColor.gray900,
+                        spoonyColor.black
+                    ),
+                    start = Offset(0f, Float.POSITIVE_INFINITY),
+                    end = Offset(Float.POSITIVE_INFINITY, 0f)
+                )
+                IconTagColor.White -> SolidColor(spoonyColor.white)
+                IconTagColor.Main -> SolidColor(spoonyColor.main400)
+                else -> SolidColor(spoonyColor.white)
+            }
+            TagSize.Small -> when (tagColor) {
+                IconTagColor.Main -> SolidColor(spoonyColor.main0)
+                IconTagColor.Orange -> SolidColor(spoonyColor.orange100)
+                IconTagColor.Pink -> SolidColor(spoonyColor.pink100)
+                IconTagColor.Green -> SolidColor(spoonyColor.green100)
+                IconTagColor.Blue -> SolidColor(spoonyColor.blue100)
+                IconTagColor.Purple -> SolidColor(spoonyColor.purple100)
+                else -> SolidColor(spoonyColor.black)
+            }
+        }
+    }
+    val paddingValues = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> PaddingValues(horizontal = 16.dp, vertical = 6.dp)
+            TagSize.Small -> PaddingValues(horizontal = 10.dp, vertical = 4.dp)
+        }
+    }
+    val iconTextColor = remember(tagSize, tagColor) {
+        when (tagSize) {
+            TagSize.Large -> when (tagColor) {
+                IconTagColor.Black -> spoonyColor.white
+                IconTagColor.White -> spoonyColor.gray600
+                IconTagColor.Main -> spoonyColor.white
+                else -> spoonyColor.black
+            }
+            TagSize.Small -> when (tagColor) {
+                IconTagColor.Main -> spoonyColor.main400
+                IconTagColor.Orange -> spoonyColor.orange400
+                IconTagColor.Pink -> spoonyColor.pink400
+                IconTagColor.Green -> spoonyColor.green400
+                IconTagColor.Blue -> spoonyColor.blue400
+                IconTagColor.Purple -> spoonyColor.purple400
+                else -> spoonyColor.white
+            }
+        }
+    }
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(brush = backgroundBrush)
+            .clickable(onClick = onClick)
+            .padding(paddingValues),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        if (icon != null) {
+            icon.invoke(iconTextColor)
+            Spacer(modifier = Modifier.width(4.dp))
+        }
+        Text(
+            text = text,
+            color = iconTextColor,
+            style = textStyle
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun IconTagPreview(
+    @PreviewParameter(TagSizeProvider::class) size: TagSize
+) {
+    SpoonyAndroidTheme {
+        Column(
+            modifier = Modifier,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            IconTagColor.entries
+                .filter { color ->
+                    if (size == TagSize.Large) {
+                        color == IconTagColor.Black ||
+                            color == IconTagColor.White ||
+                            color == IconTagColor.Main
+                    } else {
+                        color != IconTagColor.Black && color != IconTagColor.White
+                    }
+                }
+                .forEach { color ->
+                    IconTag(
+                        text = "chip",
+                        tagSize = size,
+                        tagColor = color,
+                        onClick = { },
+                        icon = { tint ->
+                            Icon(
+                                painter = painterResource(R.drawable.ic_american_24), // 예시로 Star 아이콘 사용
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp),
+                                tint = tint
+                            )
+                        }
+                    )
+                }
+        }
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/LogoTag.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/LogoTag.kt
@@ -29,7 +29,7 @@ import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.designsystem.type.TagSize
 
 @Composable
-fun SpoonyTag(
+fun LogoTag(
     count: Int,
     onClick: () -> Unit,
     tagSize: TagSize = TagSize.Small,
@@ -97,7 +97,7 @@ fun SpoonyTag(
     }
 }
 
-private class TagSizeProvider : PreviewParameterProvider<TagSize> {
+class TagSizeProvider : PreviewParameterProvider<TagSize> {
     override val values: Sequence<TagSize> = sequenceOf(
         TagSize.Large,
         TagSize.Small
@@ -106,11 +106,11 @@ private class TagSizeProvider : PreviewParameterProvider<TagSize> {
 
 @Preview
 @Composable
-private fun SpoonyTagPreview(
+private fun LogoTagPreview(
     @PreviewParameter(TagSizeProvider::class) size: TagSize
 ) {
     SpoonyAndroidTheme {
-        SpoonyTag(
+        LogoTag(
             count = 99,
             tagSize = size,
             onClick = {}

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/SpoonyTag.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/SpoonyTag.kt
@@ -26,41 +26,41 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.spoony.spoony.R
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
-import com.spoony.spoony.core.designsystem.type.TagType
+import com.spoony.spoony.core.designsystem.type.TagSize
 
 @Composable
 fun SpoonyTag(
     count: Int,
     onClick: () -> Unit,
-    tagType: TagType = TagType.Small,
+    tagSize: TagSize = TagSize.Small,
     modifier: Modifier = Modifier
 ) {
     val spoonTypography = SpoonyAndroidTheme.typography
-    val textSize = remember(tagType) {
-        when (tagType) {
-            TagType.Large -> spoonTypography.body1sb
-            TagType.Small -> spoonTypography.body2sb
+    val textSize = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> spoonTypography.body1sb
+            TagSize.Small -> spoonTypography.body2sb
         }
     }
 
-    val paddingValues = remember(tagType) {
-        when (tagType) {
-            TagType.Large -> PaddingValues(start = 12.dp, end = 4.dp, top = 5.dp, bottom = 4.dp)
-            TagType.Small -> PaddingValues(start = 8.dp, end = 2.dp, top = 4.dp, bottom = 4.dp)
+    val paddingValues = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> PaddingValues(start = 12.dp, end = 4.dp, top = 5.dp, bottom = 4.dp)
+            TagSize.Small -> PaddingValues(start = 8.dp, end = 2.dp, top = 4.dp, bottom = 4.dp)
         }
     }
 
-    val betweenPaddingValues = remember(tagType) {
-        when (tagType) {
-            TagType.Large -> 6.dp
-            TagType.Small -> 5.dp
+    val betweenPaddingValues = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> 6.dp
+            TagSize.Small -> 5.dp
         }
     }
 
-    val verticalAlignment = remember(tagType) {
-        when (tagType) {
-            TagType.Large -> Alignment.Top
-            TagType.Small -> Alignment.CenterVertically
+    val verticalAlignment = remember(tagSize) {
+        when (tagSize) {
+            TagSize.Large -> Alignment.Top
+            TagSize.Small -> Alignment.CenterVertically
         }
     }
 
@@ -97,22 +97,22 @@ fun SpoonyTag(
     }
 }
 
-private class TagTypeProvider : PreviewParameterProvider<TagType> {
-    override val values: Sequence<TagType> = sequenceOf(
-        TagType.Large,
-        TagType.Small
+private class TagSizeProvider : PreviewParameterProvider<TagSize> {
+    override val values: Sequence<TagSize> = sequenceOf(
+        TagSize.Large,
+        TagSize.Small
     )
 }
 
 @Preview
 @Composable
 private fun SpoonyTagPreview(
-    @PreviewParameter(TagTypeProvider::class) type: TagType
+    @PreviewParameter(TagSizeProvider::class) size: TagSize
 ) {
     SpoonyAndroidTheme {
         SpoonyTag(
             count = 99,
-            tagType = type,
+            tagSize = size,
             onClick = {}
         )
     }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/SpoonyTag.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/tag/SpoonyTag.kt
@@ -1,0 +1,119 @@
+package com.spoony.spoony.core.designsystem.component.tag
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.spoony.spoony.R
+import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
+import com.spoony.spoony.core.designsystem.type.TagType
+
+@Composable
+fun SpoonyTag(
+    count: Int,
+    onClick: () -> Unit,
+    tagType: TagType = TagType.Small,
+    modifier: Modifier = Modifier
+) {
+    val spoonTypography = SpoonyAndroidTheme.typography
+    val textSize = remember(tagType) {
+        when (tagType) {
+            TagType.Large -> spoonTypography.body1sb
+            TagType.Small -> spoonTypography.body2sb
+        }
+    }
+
+    val paddingValues = remember(tagType) {
+        when (tagType) {
+            TagType.Large -> PaddingValues(start = 12.dp, end = 4.dp, top = 5.dp, bottom = 4.dp)
+            TagType.Small -> PaddingValues(start = 8.dp, end = 2.dp, top = 4.dp, bottom = 4.dp)
+        }
+    }
+
+    val betweenPaddingValues = remember(tagType) {
+        when (tagType) {
+            TagType.Large -> 6.dp
+            TagType.Small -> 5.dp
+        }
+    }
+
+    val verticalAlignment = remember(tagType) {
+        when (tagType) {
+            TagType.Large -> Alignment.Top
+            TagType.Small -> Alignment.CenterVertically
+        }
+    }
+
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(
+                Brush.linearGradient(
+                    colors = listOf(
+                        SpoonyAndroidTheme.colors.gray800,
+                        SpoonyAndroidTheme.colors.gray900,
+                        SpoonyAndroidTheme.colors.black
+                    ),
+                    start = Offset(0f, Float.POSITIVE_INFINITY),
+                    end = Offset(Float.POSITIVE_INFINITY, 0f)
+                )
+            )
+            .clickable { onClick() }
+            .padding(paddingValues),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = verticalAlignment
+    ) {
+        Text(
+            text = count.toString(),
+            style = textSize,
+            color = SpoonyAndroidTheme.colors.white
+        )
+        Spacer(modifier = Modifier.width(betweenPaddingValues))
+        Icon(
+            painter = painterResource(id = R.drawable.ic_tag_spoon_20),
+            contentDescription = "Arrow Icon",
+            tint = Color.Unspecified
+        )
+    }
+}
+
+private class TagTypeProvider : PreviewParameterProvider<TagType> {
+    override val values: Sequence<TagType> = sequenceOf(
+        TagType.Large,
+        TagType.Small
+    )
+}
+
+@Preview
+@Composable
+private fun SpoonyTagPreview(
+    @PreviewParameter(TagTypeProvider::class) type: TagType
+) {
+    SpoonyAndroidTheme {
+        SpoonyTag(
+            count = 99,
+            tagType = type,
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
@@ -1,0 +1,5 @@
+package com.spoony.spoony.core.designsystem.type
+
+enum class TagType {
+    Large, Small
+}

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
@@ -1,5 +1,5 @@
 package com.spoony.spoony.core.designsystem.type
 
-enum class TagType {
+enum class TagSize {
     Large, Small
 }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/type/TagType.kt
@@ -3,3 +3,7 @@ package com.spoony.spoony.core.designsystem.type
 enum class TagSize {
     Large, Small
 }
+
+enum class IconTagColor {
+    Black, White, Main, Orange, Pink, Green, Blue, Purple
+}

--- a/app/src/main/res/drawable/ic_tag_spoon_20.xml
+++ b/app/src/main/res/drawable/ic_tag_spoon_20.xml
@@ -1,0 +1,99 @@
+<vector xmlns:aapt="http://schemas.android.com/aapt" xmlns:android="http://schemas.android.com/apk/res/android" android:height="19.130434dp" android:viewportHeight="22" android:viewportWidth="23" android:width="20dp">
+      
+    <path android:fillType="evenOdd" android:pathData="M11.583,12.236C11.504,12.316 11.455,12.421 11.441,12.533C11.238,14.132 10.492,16.365 8.425,17.717C5.143,19.864 1.534,17.826 1.268,17.306C0.746,16.281 3.876,13.557 5.698,12.365C6.938,11.554 9.264,10.418 10.548,10.357C10.694,10.35 10.837,10.299 10.939,10.194L11.81,9.31L23.066,0.192C23.464,-0.135 24.021,-0.034 24.309,0.417C24.597,0.868 24.508,1.499 24.11,1.826L12.855,10.944L11.583,12.236Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="-1.744" android:endY="16.403" android:startX="18.908" android:startY="5.675" android:type="linear">
+                        
+                <item android:color="#19FFFFFF" android:offset="0"/>
+                        
+                <item android:color="#FFFFFFFF" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+      
+    <path android:pathData="M10.609,10.92C10.826,11.346 9.175,13.3 6.726,14.901C4.277,16.503 1.958,17.146 1.741,16.721C1.524,16.295 3.275,14.537 5.724,12.936C8.173,11.334 10.392,10.494 10.609,10.92Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="11.178" android:endY="12.036" android:startX="1.791" android:startY="16.819" android:type="linear">
+                        
+                <item android:color="#26171719" android:offset="0"/>
+                        
+                <item android:color="#72171719" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+      
+    <path android:pathData="M3.632,3.706C3.648,3.655 3.678,3.61 3.718,3.579C3.757,3.548 3.804,3.531 3.852,3.531C3.901,3.531 3.948,3.548 3.987,3.579C4.027,3.61 4.057,3.655 4.073,3.706L4.298,4.401C4.474,4.946 4.753,5.441 5.115,5.851C5.477,6.262 5.914,6.578 6.395,6.777L7.009,7.032C7.054,7.051 7.093,7.085 7.121,7.129C7.148,7.174 7.163,7.227 7.163,7.282C7.163,7.336 7.148,7.39 7.121,7.434C7.093,7.479 7.054,7.513 7.009,7.532L6.395,7.786C5.914,7.986 5.477,8.302 5.115,8.712C4.753,9.123 4.474,9.618 4.298,10.163L4.073,10.858C4.057,10.909 4.027,10.953 3.987,10.984C3.948,11.016 3.901,11.033 3.852,11.033C3.804,11.033 3.757,11.016 3.718,10.984C3.678,10.953 3.648,10.909 3.632,10.858L3.407,10.163C3.231,9.618 2.952,9.123 2.59,8.712C2.228,8.302 1.791,7.986 1.31,7.786L0.696,7.532C0.651,7.513 0.612,7.479 0.584,7.434C0.557,7.39 0.542,7.336 0.542,7.282C0.542,7.227 0.557,7.174 0.584,7.129C0.612,7.085 0.651,7.051 0.696,7.032L1.31,6.777C1.791,6.578 2.228,6.262 2.59,5.851C2.952,5.441 3.231,4.946 3.407,4.401L3.632,3.706Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="8.05" android:endY="10.158" android:startX="0.542" android:startY="3.531" android:type="linear">
+                        
+                <item android:color="#FFFFFFFF" android:offset="0"/>
+                        
+                <item android:color="#66FFFFFF" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+      
+    <path android:fillType="evenOdd" android:pathData="M11.583,12.236C11.504,12.316 11.455,12.421 11.441,12.533C11.238,14.132 10.492,16.365 8.425,17.717C5.143,19.864 1.534,17.826 1.268,17.306C0.746,16.281 3.876,13.557 5.698,12.365C6.938,11.554 9.264,10.418 10.548,10.357C10.694,10.35 10.837,10.299 10.939,10.194L11.81,9.31L23.066,0.192C23.464,-0.135 24.021,-0.034 24.309,0.417C24.597,0.868 24.508,1.499 24.11,1.826L12.855,10.944L11.583,12.236Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="-1.744" android:endY="16.403" android:startX="18.908" android:startY="5.675" android:type="linear">
+                        
+                <item android:color="#19FFFFFF" android:offset="0"/>
+                        
+                <item android:color="#FFFFFFFF" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+      
+    <path android:pathData="M10.609,10.92C10.826,11.346 9.175,13.3 6.726,14.901C4.277,16.503 1.958,17.146 1.741,16.721C1.524,16.295 3.275,14.537 5.724,12.936C8.173,11.334 10.392,10.494 10.609,10.92Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="11.178" android:endY="12.036" android:startX="1.791" android:startY="16.819" android:type="linear">
+                        
+                <item android:color="#26171719" android:offset="0"/>
+                        
+                <item android:color="#72171719" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+      
+    <path android:pathData="M3.632,3.706C3.648,3.655 3.678,3.61 3.718,3.579C3.757,3.548 3.804,3.531 3.852,3.531C3.901,3.531 3.948,3.548 3.987,3.579C4.027,3.61 4.057,3.655 4.073,3.706L4.298,4.401C4.474,4.946 4.753,5.441 5.115,5.851C5.477,6.262 5.914,6.578 6.395,6.777L7.009,7.032C7.054,7.051 7.093,7.085 7.121,7.129C7.148,7.174 7.163,7.227 7.163,7.282C7.163,7.336 7.148,7.39 7.121,7.434C7.093,7.479 7.054,7.513 7.009,7.532L6.395,7.786C5.914,7.986 5.477,8.302 5.115,8.712C4.753,9.123 4.474,9.618 4.298,10.163L4.073,10.858C4.057,10.909 4.027,10.953 3.987,10.984C3.948,11.016 3.901,11.033 3.852,11.033C3.804,11.033 3.757,11.016 3.718,10.984C3.678,10.953 3.648,10.909 3.632,10.858L3.407,10.163C3.231,9.618 2.952,9.123 2.59,8.712C2.228,8.302 1.791,7.986 1.31,7.786L0.696,7.532C0.651,7.513 0.612,7.479 0.584,7.434C0.557,7.39 0.542,7.336 0.542,7.282C0.542,7.227 0.557,7.174 0.584,7.129C0.612,7.085 0.651,7.051 0.696,7.032L1.31,6.777C1.791,6.578 2.228,6.262 2.59,5.851C2.952,5.441 3.231,4.946 3.407,4.401L3.632,3.706Z">
+            
+        <aapt:attr name="android:fillColor">
+                  
+            <gradient android:endX="8.05" android:endY="10.158" android:startX="0.542" android:startY="3.531" android:type="linear">
+                        
+                <item android:color="#FFFFFFFF" android:offset="0"/>
+                        
+                <item android:color="#66FFFFFF" android:offset="1"/>
+                      
+            </gradient>
+                
+        </aapt:attr>
+          
+    </path>
+    
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #20 

## Work Description ✏️
- 공통 컴포넌트 Tag 구현

## Screenshot 📸
<img width="360" alt="image" src="https://github.com/user-attachments/assets/8d67ea34-93e1-42b2-90ab-d6ad1c9dffbc" />

<img width="360" alt="image" src="https://github.com/user-attachments/assets/b0b58f81-c67b-45aa-b0eb-4836fa8384a8" />

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢
Logo 를 Enum 형태를 고정할까 Icon 전달로할까 고민하다가 공통 컴포넌트를 만드는 것이기 때문에 확장성을 고려한다면 Icon 을 전달하는 것이 맞지 않을까라고 생각해서 Icon을 전달하도록 구현하였습니다.
<img width="622" alt="image" src="https://github.com/user-attachments/assets/3ef07d08-07da-40f5-995b-d6c208146b47" />
enum으로 설정해서 icon 하나하나 지정해야된다면 수정하겠습니다! 의견 부탁드려요!