### PR TITLE
[Feat/#32] 장소 상세 페이지 IconDropdown 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.timber)
     implementation(libs.lottie)
+
+    implementation(libs.kotlinx.immutable)
 }
 
 ktlint {

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -94,7 +94,7 @@ fun IconDropdownMenu(
 
 @Preview
 @Composable
-fun IconDropdownMenuOnePreview() {
+private fun IconDropdownMenuOnePreview() {
     val menuItems = listOf("신고하기")
     SpoonyAndroidTheme {
         IconDropdownMenu(
@@ -108,7 +108,7 @@ fun IconDropdownMenuOnePreview() {
 
 @Preview
 @Composable
-fun IconDropdownMenuTwoPreview() {
+private fun IconDropdownMenuTwoPreview() {
     val menuItems = listOf("신고하기", "수정하기")
     SpoonyAndroidTheme {
         IconDropdownMenu(

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -29,10 +29,12 @@ import androidx.compose.ui.unit.dp
 import com.spoony.spoony.R
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.util.extension.noRippleClickable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun IconDropdownMenu(
-    menuItems: List<String>,
+    menuItems: ImmutableList<String>,
     onMenuItemClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -95,7 +97,7 @@ fun IconDropdownMenu(
 @Preview
 @Composable
 private fun IconDropdownMenuOnePreview() {
-    val menuItems = listOf("신고하기")
+    val menuItems = listOf("신고하기").toImmutableList()
     SpoonyAndroidTheme {
         IconDropdownMenu(
             menuItems = menuItems,
@@ -109,7 +111,7 @@ private fun IconDropdownMenuOnePreview() {
 @Preview
 @Composable
 private fun IconDropdownMenuTwoPreview() {
-    val menuItems = listOf("신고하기", "수정하기")
+    val menuItems = listOf("신고하기", "수정하기").toImmutableList()
     SpoonyAndroidTheme {
         IconDropdownMenu(
             menuItems = menuItems,

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -30,7 +30,7 @@ import com.spoony.spoony.R
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.util.extension.noRippleClickable
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.immutableListOf
 
 @Composable
 fun IconDropdownMenu(
@@ -97,7 +97,7 @@ fun IconDropdownMenu(
 @Preview
 @Composable
 private fun IconDropdownMenuOnePreview() {
-    val menuItems = listOf("신고하기").toImmutableList()
+    val menuItems = immutableListOf("신고하기")
     SpoonyAndroidTheme {
         IconDropdownMenu(
             menuItems = menuItems,
@@ -111,7 +111,7 @@ private fun IconDropdownMenuOnePreview() {
 @Preview
 @Composable
 private fun IconDropdownMenuTwoPreview() {
-    val menuItems = listOf("신고하기", "수정하기").toImmutableList()
+    val menuItems = immutableListOf("신고하기", "수정하기")
     SpoonyAndroidTheme {
         IconDropdownMenu(
             menuItems = menuItems,

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
@@ -72,7 +72,7 @@ fun IconDropdownMenu(
                         key(menuItem) {
                             Box(
                                 modifier = Modifier
-                                    .width(91.dp)
+                                    .widthIn(min = 91.dp)
                                     .noRippleClickable {
                                         onMenuItemClick(menuItem)
                                         expanded = false

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -55,7 +54,6 @@ fun IconDropdownMenu(
             DropdownMenu(
                 expanded = expanded,
                 modifier = Modifier
-                    .shadow(30.dp, RoundedCornerShape(10.dp))
                     .background(
                         color = SpoonyAndroidTheme.colors.white,
                         shape = RoundedCornerShape(10.dp)

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -66,21 +67,23 @@ fun IconDropdownMenu(
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     menuItems.forEach { menuItem ->
-                        Box(
-                            modifier = Modifier
-                                .width(91.dp)
-                                .noRippleClickable {
-                                    onMenuItemClick(menuItem)
-                                    expanded = false
-                                }
-                                .padding(6.dp),
-                            contentAlignment = Alignment.CenterStart
-                        ) {
-                            Text(
-                                text = menuItem,
-                                style = SpoonyAndroidTheme.typography.caption1b,
-                                color = SpoonyAndroidTheme.colors.gray900
-                            )
+                        key(menuItem) {
+                            Box(
+                                modifier = Modifier
+                                    .width(91.dp)
+                                    .noRippleClickable {
+                                        onMenuItemClick(menuItem)
+                                        expanded = false
+                                    }
+                                    .padding(6.dp),
+                                contentAlignment = Alignment.CenterStart
+                            ) {
+                                Text(
+                                    text = menuItem,
+                                    style = SpoonyAndroidTheme.typography.caption1b,
+                                    color = SpoonyAndroidTheme.colors.gray900
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/IconDropdownMenu.kt
@@ -1,0 +1,121 @@
+package com.spoony.spoony.presentation.placeDetail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.spoony.spoony.R
+import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
+import com.spoony.spoony.core.util.extension.noRippleClickable
+
+@Composable
+fun IconDropdownMenu(
+    menuItems: List<String>,
+    onMenuItemClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Column(modifier = modifier.wrapContentSize(Alignment.TopEnd)) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_menu_24),
+            contentDescription = null,
+            tint = SpoonyAndroidTheme.colors.gray500,
+            modifier = Modifier
+                .noRippleClickable {
+                    expanded = !expanded
+                }
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        MaterialTheme(
+            shapes = MaterialTheme.shapes.copy(RoundedCornerShape(10.dp))
+        ) {
+            DropdownMenu(
+                expanded = expanded,
+                modifier = Modifier
+                    .shadow(30.dp, RoundedCornerShape(10.dp))
+                    .background(
+                        color = SpoonyAndroidTheme.colors.white,
+                        shape = RoundedCornerShape(10.dp)
+                    )
+                    .padding(
+                        vertical = 2.dp,
+                        horizontal = 8.dp
+                    ),
+                onDismissRequest = { expanded = false }
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    menuItems.forEach { menuItem ->
+                        Box(
+                            modifier = Modifier
+                                .width(91.dp)
+                                .noRippleClickable {
+                                    onMenuItemClick(menuItem)
+                                    expanded = false
+                                }
+                                .padding(6.dp),
+                            contentAlignment = Alignment.CenterStart
+                        ) {
+                            Text(
+                                text = menuItem,
+                                style = SpoonyAndroidTheme.typography.caption1b,
+                                color = SpoonyAndroidTheme.colors.gray900
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun IconDropdownMenuOnePreview() {
+    val menuItems = listOf("신고하기")
+    SpoonyAndroidTheme {
+        IconDropdownMenu(
+            menuItems = menuItems,
+            onMenuItemClick = { selectedItem ->
+                // selectedItem
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+fun IconDropdownMenuTwoPreview() {
+    val menuItems = listOf("신고하기", "수정하기")
+    SpoonyAndroidTheme {
+        IconDropdownMenu(
+            menuItems = menuItems,
+            onMenuItemClick = { selectedItem ->
+                // selectedItem
+            }
+        )
+    }
+}

--- a/app/src/main/res/drawable/ic_menu_24.xml
+++ b/app/src/main/res/drawable/ic_menu_24.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,4m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#878A93"/>
+  <path
+      android:pathData="M12,12m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#878A93"/>
+  <path
+      android:pathData="M12,20m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0"
+      android:fillColor="#878A93"/>
+</vector>


### PR DESCRIPTION
## Related issue 🛠
- closed #32 

## Work Description ✏️
- 장소 상세 페이지 IconDropdown 구현

## Screenshot 📸
<img width="230" alt="image" src="https://github.com/user-attachments/assets/60326a5d-57a4-45ed-a40c-5669e0171773" />
<img width="227" alt="image" src="https://github.com/user-attachments/assets/4a80b65d-f7a8-4b73-a9a8-8da02bdb2307" />