### PR TITLE
[FEAT/#97] 배경색 설정 및 가로모드 막기

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
         jvmTarget = libs.versions.jvmTarget.get()

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Theme.kt
@@ -1,11 +1,17 @@
 package com.spoony.spoony.core.designsystem.theme
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+
+private val LightColorScheme = lightColorScheme(
+    primary = main400,
+    background = white
+)
 
 private val LocalSpoonyColors = staticCompositionLocalOf<SpoonyColors> {
     error("No SpoonyColors provided")
@@ -52,8 +58,12 @@ fun ProvideSpoonyColorsAndTypography(
 @Composable
 fun SpoonyAndroidTheme(darkTheme: Boolean = false, content: @Composable () -> Unit) {
     val colors = SpoonyLightColors()
+    val colorScheme = LightColorScheme
     val typography = SpoonyTypography()
     ProvideSpoonyColorsAndTypography(colors, typography) {
-        MaterialTheme(content = content)
+        MaterialTheme(
+            colorScheme = colorScheme,
+            content = content
+        )
     }
 }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Theme.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/theme/Theme.kt
@@ -1,12 +1,16 @@
 package com.spoony.spoony.core.designsystem.theme
 
+import android.app.Activity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 private val LightColorScheme = lightColorScheme(
     primary = main400,
@@ -60,6 +64,19 @@ fun SpoonyAndroidTheme(darkTheme: Boolean = false, content: @Composable () -> Un
     val colors = SpoonyLightColors()
     val colorScheme = LightColorScheme
     val typography = SpoonyTypography()
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+
+            WindowCompat.getInsetsController(window, view)
+                .isAppearanceLightStatusBars = true
+            WindowCompat.getInsetsController(window, view)
+                .isAppearanceLightNavigationBars = true
+        }
+    }
+
     ProvideSpoonyColorsAndTypography(colors, typography) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/app/src/main/java/com/spoony/spoony/presentation/MainActivity.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.spoony.spoony.presentation
 
+import android.annotation.SuppressLint
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,8 +12,10 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         enableEdgeToEdge()
         setContent {
             SpoonyAndroidTheme {

--- a/app/src/main/java/com/spoony/spoony/presentation/MainActivity.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/MainActivity.kt
@@ -4,10 +4,6 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.presentation.main.MainScreen
 import dagger.hilt.android.AndroidEntryPoint
@@ -22,21 +18,5 @@ class MainActivity : ComponentActivity() {
                 MainScreen()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    SpoonyAndroidTheme {
-        Greeting("Android")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 compileSdk = "35"
 minSdk = "28"
 targetSdk = "35"
-jvmTarget = "1.8"
+jvmTarget = "11"
 versionCode = "1"
 versionName = "1.0.0"
 kotlinCompilerExtensionVersion = "1.5.15"


### PR DESCRIPTION
## Related issue 🛠
- closed #97 

## Work Description ✏️
- 배경색 하얀색으로 설정
- 가로모드 막기

## Screenshot 📸
N/A

## Uncompleted Tasks 😅
- [x] 다크모드 막기

## To Reviewers 📢
드디어 배경색과 가로모드를 막았습니다!!
다크모드,,도 함께 막아보려고 했는데 이미 막혀있더라구요..?? 근데 왜 다크모드가 설정되는지는 지금부터 알아보겠습니다😂
==> 다크모드도 막기 성공!!

다크모드를 막는 과정에서 JVM 버전이 변경되었는데 지도때문에 JVM은 바뀔 예정이었어서 그냥 현재 브랜치에서 수정했습니다! 참고 부탁드려요😊