### PR TITLE
[FEAT/#177] 탐색 뷰 사용자 스푼 개수 API 연결 및 장소 상세 떠먹었을 시 스푼 개수 업데이트

### DIFF
--- a/app/src/main/java/com/spoony/spoony/presentation/explore/ExploreScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/explore/ExploreScreen.kt
@@ -61,6 +61,10 @@ fun ExploreRoute(
         else -> 0
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.getSpoonAccount()
+    }
+
     val categoryList = when (state.categoryList) {
         is UiState.Success -> (state.categoryList as? UiState.Success<ImmutableList<CategoryEntity>>)?.data ?: persistentListOf()
         else -> persistentListOf()

--- a/app/src/main/java/com/spoony/spoony/presentation/explore/ExploreViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/explore/ExploreViewModel.kt
@@ -3,6 +3,8 @@ package com.spoony.spoony.presentation.explore
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.spoony.spoony.core.state.UiState
+import com.spoony.spoony.core.util.USER_ID
+import com.spoony.spoony.domain.repository.AuthRepository
 import com.spoony.spoony.domain.repository.ExploreRepository
 import com.spoony.spoony.presentation.explore.model.toModel
 import com.spoony.spoony.presentation.explore.type.SortingOption
@@ -16,7 +18,8 @@ import kotlinx.coroutines.launch
 
 @HiltViewModel
 class ExploreViewModel @Inject constructor(
-    private val exploreRepository: ExploreRepository
+    private val exploreRepository: ExploreRepository,
+    private val authRepository: AuthRepository
 ) : ViewModel() {
     private var _state: MutableStateFlow<ExploreState> = MutableStateFlow(ExploreState())
     val state: StateFlow<ExploreState>
@@ -41,6 +44,19 @@ class ExploreViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             categoryList = UiState.Failure("카테고리 목록 조회 실패")
+                        )
+                    }
+                }
+        }
+    }
+
+    fun getSpoonAccount() {
+        viewModelScope.launch {
+            authRepository.getSpoonCount(userId = USER_ID)
+                .onSuccess { response ->
+                    _state.update {
+                        it.copy(
+                            spoonCount = UiState.Success(response)
                         )
                     }
                 }

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailViewModel.kt
@@ -117,7 +117,11 @@ class PlaceDetailViewModel @Inject constructor(
                 .onSuccess {
                     _state.update {
                         it.copy(
-                            isScooped = true
+                            isScooped = true,
+                            spoonCount = when (val spoonState = it.spoonCount) {
+                                is UiState.Success -> UiState.Success(spoonState.data - 1)
+                                else -> spoonState
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
## Related issue 🛠
- closed #177 

## Work Description ✏️
- 탐색 뷰 사용자 스푼 개수 API 연결 및 장소 상세 떠먹었을 시 스푼 개수 업데이트

## Screenshot 📸
https://github.com/user-attachments/assets/ba7b84ba-6caf-42ce-af28-1474d60b1e7b

## To Reviewers 📢