### PR TITLE
[FIX/#188] 드롭다운 메뉴 리스트가 비었을 경우 드롭다운 메뉴 아이콘이 안보이도록 수정

### DIFF
--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailRoute.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/PlaceDetailRoute.kt
@@ -239,17 +239,18 @@ private fun PlaceDetailScreen(
                 location = "서울시 $userRegion 수저",
                 modifier = Modifier.weight(1f)
             )
-
-            IconDropdownMenu(
-                menuItems = dropdownMenuList,
-                onMenuItemClick = { menu ->
-                    when (menu) {
-                        DropdownOption.REPORT.name -> {
-                            onReportButtonClick()
+            if (dropdownMenuList.isNotEmpty()) {
+                IconDropdownMenu(
+                    menuItems = dropdownMenuList,
+                    onMenuItemClick = { menu ->
+                        when (menu) {
+                            DropdownOption.REPORT.name -> {
+                                onReportButtonClick()
+                            }
                         }
                     }
-                }
-            )
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
## Related issue 🛠
- closed #188 

## Work Description ✏️
- 드롭다운 메뉴 리스트가 비었을 경우 드롭다운 메뉴 아이콘이 안보이도록 수정

## Screenshot 📸
<img src="https://github.com/user-attachments/assets/dbe11774-11cf-4e04-b1d6-ce788730ca77" width="300">
<img src="https://github.com/user-attachments/assets/ec21676f-9346-4422-a1cd-e85695410261" width="300">

## To Reviewers 📢