### PR TITLE
[REF/#398] 탐색 검색 뷰 파라미터 줄이기 리펙토링

### DIFF
--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -78,9 +79,13 @@ fun ExploreSearchRoute(
     LaunchedEffect(viewModel.sideEffect, lifecycleOwner) {
         viewModel.sideEffect.flowWithLifecycle(lifecycleOwner.lifecycle).collect { effect ->
             when (effect) {
-                is ExploreSearchSideEffect.ShowSnackBar -> {
-                    showSnackBar(effect.message)
-                }
+                is ExploreSearchSideEffect.ShowSnackBar -> showSnackBar(effect.message)
+                is ExploreSearchSideEffect.NavigateToUserProfile -> navigateToUserProfile(effect.userId)
+                is ExploreSearchSideEffect.NavigateToMyPage -> navigateToMyPage()
+                is ExploreSearchSideEffect.NavigateToPlaceDetail -> navigateToPlaceDetail(effect.placeId)
+                is ExploreSearchSideEffect.NavigateBack -> navigateUp()
+                is ExploreSearchSideEffect.NavigateToReport -> navigateToReport(effect.targetId, effect.type)
+                is ExploreSearchSideEffect.NavigateToEdit -> navigateToEditReview(effect.reviewId, effect.type)
             }
         }
     }
@@ -96,22 +101,11 @@ fun ExploreSearchRoute(
         paddingValues = paddingValues,
         searchKeyword = state.searchKeyword,
         searchType = state.searchType,
-        onReviewReportButtonClick = navigateToReport,
-        onUserButtonClick = navigateToUserProfile,
-        onMyPageButtonClick = navigateToMyPage,
-        onPlaceDetailButtonClick = navigateToPlaceDetail,
-        onBackButtonClick = navigateUp,
-        onSwitchType = viewModel::switchSearchType,
-        onRemoveRecentSearchItem = viewModel::removeRecentSearchItem,
-        onClearRecentSearchItem = viewModel::clearRecentSearchItem,
-        onSearch = viewModel::search,
-        onEditReviewClick = navigateToEditReview,
-        onClearSearchKeyword = viewModel::clearSearchKeyword,
-        onReviewDeleteButtonClick = viewModel::deleteReview,
         recentReviewSearchQueryList = state.recentReviewSearchQueryList,
         recentUserSearchQueryList = state.recentUserSearchQueryList,
         userInfoList = state.userInfoList,
-        placeReviewInfoList = state.placeReviewInfoList
+        placeReviewInfoList = state.placeReviewInfoList,
+        onAction = viewModel::onAction
     )
 }
 
@@ -120,22 +114,11 @@ private fun ExploreSearchScreen(
     paddingValues: PaddingValues,
     searchKeyword: String,
     searchType: SearchType,
-    onReviewReportButtonClick: (reportTargetId: Int, type: ReportType) -> Unit,
-    onUserButtonClick: (Int) -> Unit,
-    onPlaceDetailButtonClick: (Int) -> Unit,
-    onMyPageButtonClick: () -> Unit,
-    onBackButtonClick: () -> Unit,
-    onRemoveRecentSearchItem: (String) -> Unit,
-    onSwitchType: (SearchType) -> Unit,
-    onClearRecentSearchItem: () -> Unit,
-    onSearch: (String) -> Unit,
-    onEditReviewClick: (Int, RegisterType) -> Unit,
-    onClearSearchKeyword: () -> Unit,
-    onReviewDeleteButtonClick: (Int) -> Unit,
     recentReviewSearchQueryList: ImmutableList<String>,
     recentUserSearchQueryList: ImmutableList<String>,
     userInfoList: UiState<ImmutableList<ExploreSearchUserModel>>,
-    placeReviewInfoList: UiState<ImmutableList<ExploreSearchPlaceReviewModel>>
+    placeReviewInfoList: UiState<ImmutableList<ExploreSearchPlaceReviewModel>>,
+    onAction: (ExploreSearchAction) -> Unit
 ) {
     val focusRequester = remember { FocusRequester() }
     val focusManager = LocalFocusManager.current
@@ -151,7 +134,7 @@ private fun ExploreSearchScreen(
             positiveText = "네",
             onClickNegative = { isReviewDeleteDialogVisible = false },
             onClickPositive = {
-                onReviewDeleteButtonClick(targetReviewId)
+                onAction(ExploreSearchAction.DeleteReview(targetReviewId))
                 isReviewDeleteDialogVisible = false
             },
             onDismiss = { }
@@ -166,25 +149,24 @@ private fun ExploreSearchScreen(
 
     LaunchedEffect(searchText) {
         if (searchText.isEmpty()) {
-            onClearSearchKeyword()
+            onAction(ExploreSearchAction.ClearSearchKeyword)
         }
     }
 
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .background(color = SpoonyAndroidTheme.colors.white)
-            .padding(
-                bottom = paddingValues.calculateBottomPadding()
-            )
+            .padding(bottom = paddingValues.calculateBottomPadding())
     ) {
         ExploreSearchTopAppbar(
             value = searchText,
             onValueChanged = {
                 searchText = it
             },
-            onBackButtonClick = onBackButtonClick,
+            onBackButtonClick = { onAction(ExploreSearchAction.ClickBack) },
             onSearchAction = {
-                onSearch(searchText)
+                onAction(ExploreSearchAction.Search(searchText))
             },
             focusRequester = focusRequester,
             searchType = searchType
@@ -211,7 +193,7 @@ private fun ExploreSearchScreen(
                     onClick = {
                         if (tabRowIndex != index) {
                             tabRowIndex = index
-                            onSwitchType(title)
+                            onAction(ExploreSearchAction.SwitchType(title))
                         }
                     },
                     selectedContentColor = SpoonyAndroidTheme.colors.white
@@ -236,11 +218,11 @@ private fun ExploreSearchScreen(
                             true -> ExploreSearchRecentEmptyScreen(searchType = searchType)
                             else ->
                                 ExploreSearchRecentContent(
-                                    onRemoveRecentSearchItem = onRemoveRecentSearchItem,
-                                    onClearRecentSearchItem = onClearRecentSearchItem,
+                                    onRemoveRecentSearchItem = { onAction(ExploreSearchAction.RemoveRecentSearch(it)) },
+                                    onClearRecentSearchItem = { onAction(ExploreSearchAction.ClearRecentSearch) },
                                     onItemClick = {
                                         searchText = it
-                                        onSearch(searchText)
+                                        onAction(ExploreSearchAction.Search(searchText))
                                         focusManager.clearFocus()
                                     },
                                     recentQueryList = recentUserSearchQueryList
@@ -263,9 +245,9 @@ private fun ExploreSearchScreen(
                                         ExploreSearchUserItem(
                                             onItemClick = {
                                                 if (userInfo.isMine) {
-                                                    onMyPageButtonClick()
+                                                    onAction(ExploreSearchAction.ClickMyPage)
                                                 } else {
-                                                    onUserButtonClick(userInfo.userId)
+                                                    onAction(ExploreSearchAction.ClickUser(userInfo.userId))
                                                 }
                                             },
                                             userInfo = userInfo
@@ -288,11 +270,11 @@ private fun ExploreSearchScreen(
                             true -> ExploreSearchRecentEmptyScreen(searchType = searchType)
                             else ->
                                 ExploreSearchRecentContent(
-                                    onRemoveRecentSearchItem = onRemoveRecentSearchItem,
-                                    onClearRecentSearchItem = onClearRecentSearchItem,
+                                    onRemoveRecentSearchItem = { onAction(ExploreSearchAction.RemoveRecentSearch(it)) },
+                                    onClearRecentSearchItem = { onAction(ExploreSearchAction.ClearRecentSearch) },
                                     onItemClick = {
                                         searchText = it
-                                        onSearch(searchText)
+                                        onAction(ExploreSearchAction.Search(searchText))
                                         focusManager.clearFocus()
                                     },
                                     recentQueryList = recentReviewSearchQueryList
@@ -332,8 +314,8 @@ private fun ExploreSearchScreen(
                                             review = placeReviewInfo.description,
                                             onMenuItemClick = {
                                                 when (it) {
-                                                    ExploreDropdownOption.REPORT.string -> onReviewReportButtonClick(placeReviewInfo.reviewId, ReportType.POST)
-                                                    ExploreDropdownOption.EDIT.string -> onEditReviewClick(placeReviewInfo.reviewId, RegisterType.EDIT)
+                                                    ExploreDropdownOption.REPORT.string -> onAction(ExploreSearchAction.ClickReviewReport(placeReviewInfo.reviewId, ReportType.POST))
+                                                    ExploreDropdownOption.EDIT.string -> onAction(ExploreSearchAction.ClickEditReview(placeReviewInfo.reviewId, RegisterType.EDIT))
                                                     ExploreDropdownOption.DELETE.string -> {
                                                         targetReviewId = placeReviewInfo.reviewId
                                                         isReviewDeleteDialogVisible = true
@@ -346,7 +328,7 @@ private fun ExploreSearchScreen(
                                             addMapCount = placeReviewInfo.addMapCount,
                                             imageList = placeReviewInfo.photoUrlList,
                                             menuItems = menuList,
-                                            onClick = onPlaceDetailButtonClick,
+                                            onClick = { placeId -> onAction(ExploreSearchAction.ClickPlaceDetail(placeId)) },
                                             category = ReviewCardCategory(
                                                 text = placeReviewInfo.category.text,
                                                 iconUrl = placeReviewInfo.category.iconUrl,

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchSideEffect.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchSideEffect.kt
@@ -1,5 +1,14 @@
 package com.spoony.spoony.presentation.exploreSearch
 
+import com.spoony.spoony.presentation.register.model.RegisterType
+import com.spoony.spoony.presentation.report.ReportType
+
 sealed class ExploreSearchSideEffect {
     data class ShowSnackBar(val message: String) : ExploreSearchSideEffect()
+    data class NavigateToUserProfile(val userId: Int) : ExploreSearchSideEffect()
+    data object NavigateToMyPage : ExploreSearchSideEffect()
+    data class NavigateToPlaceDetail(val placeId: Int) : ExploreSearchSideEffect()
+    data object NavigateBack : ExploreSearchSideEffect()
+    data class NavigateToReport(val targetId: Int, val type: ReportType) : ExploreSearchSideEffect()
+    data class NavigateToEdit(val reviewId: Int, val type: RegisterType) : ExploreSearchSideEffect()
 }

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchState.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchState.kt
@@ -4,6 +4,8 @@ import com.spoony.spoony.core.state.UiState
 import com.spoony.spoony.presentation.exploreSearch.model.ExploreSearchPlaceReviewModel
 import com.spoony.spoony.presentation.exploreSearch.model.ExploreSearchUserModel
 import com.spoony.spoony.presentation.exploreSearch.type.SearchType
+import com.spoony.spoony.presentation.register.model.RegisterType
+import com.spoony.spoony.presentation.report.ReportType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -15,3 +17,18 @@ data class ExploreSearchState(
     val userInfoList: UiState<ImmutableList<ExploreSearchUserModel>> = UiState.Loading,
     val placeReviewInfoList: UiState<ImmutableList<ExploreSearchPlaceReviewModel>> = UiState.Loading
 )
+
+sealed interface ExploreSearchAction {
+    data class ClickReviewReport(val targetId: Int, val type: ReportType) : ExploreSearchAction
+    data class ClickUser(val userId: Int) : ExploreSearchAction
+    data object ClickMyPage : ExploreSearchAction
+    data class ClickPlaceDetail(val placeId: Int) : ExploreSearchAction
+    data object ClickBack : ExploreSearchAction
+    data class RemoveRecentSearch(val keyword: String) : ExploreSearchAction
+    data class SwitchType(val type: SearchType) : ExploreSearchAction
+    data object ClearRecentSearch : ExploreSearchAction
+    data class Search(val keyword: String) : ExploreSearchAction
+    data class ClickEditReview(val reviewId: Int, val type: RegisterType) : ExploreSearchAction
+    data object ClearSearchKeyword : ExploreSearchAction
+    data class DeleteReview(val reviewId: Int) : ExploreSearchAction
+}

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchViewModel.kt
@@ -52,14 +52,17 @@ class ExploreSearchViewModel @Inject constructor(
                 is ExploreSearchAction.ClickUser ->
                     _sideEffect.emit(ExploreSearchSideEffect.NavigateToUserProfile(action.userId))
 
-                ExploreSearchAction.ClickMyPage ->
+                is ExploreSearchAction.ClickMyPage ->
                     _sideEffect.emit(ExploreSearchSideEffect.NavigateToMyPage)
 
                 is ExploreSearchAction.ClickPlaceDetail ->
                     _sideEffect.emit(ExploreSearchSideEffect.NavigateToPlaceDetail(action.placeId))
 
-                ExploreSearchAction.ClickBack ->
+                is ExploreSearchAction.ClickBack ->
                     _sideEffect.emit(ExploreSearchSideEffect.NavigateBack)
+
+                is ExploreSearchAction.ClickEditReview ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToEdit(action.reviewId, action.type))
 
                 is ExploreSearchAction.RemoveRecentSearch ->
                     removeRecentSearchItem(action.keyword)
@@ -67,16 +70,13 @@ class ExploreSearchViewModel @Inject constructor(
                 is ExploreSearchAction.SwitchType ->
                     switchSearchType(action.type)
 
-                ExploreSearchAction.ClearRecentSearch ->
+                is ExploreSearchAction.ClearRecentSearch ->
                     clearRecentSearchItem()
 
                 is ExploreSearchAction.Search ->
                     search(action.keyword)
 
-                is ExploreSearchAction.ClickEditReview ->
-                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToEdit(action.reviewId, action.type))
-
-                ExploreSearchAction.ClearSearchKeyword ->
+                is ExploreSearchAction.ClearSearchKeyword ->
                     clearSearchKeyword()
 
                 is ExploreSearchAction.DeleteReview ->

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/ExploreSearchViewModel.kt
@@ -43,6 +43,48 @@ class ExploreSearchViewModel @Inject constructor(
         getFetchRecentSearchQueries()
     }
 
+    fun onAction(action: ExploreSearchAction) {
+        viewModelScope.launch {
+            when (action) {
+                is ExploreSearchAction.ClickReviewReport ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToReport(action.targetId, action.type))
+
+                is ExploreSearchAction.ClickUser ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToUserProfile(action.userId))
+
+                ExploreSearchAction.ClickMyPage ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToMyPage)
+
+                is ExploreSearchAction.ClickPlaceDetail ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToPlaceDetail(action.placeId))
+
+                ExploreSearchAction.ClickBack ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateBack)
+
+                is ExploreSearchAction.RemoveRecentSearch ->
+                    removeRecentSearchItem(action.keyword)
+
+                is ExploreSearchAction.SwitchType ->
+                    switchSearchType(action.type)
+
+                ExploreSearchAction.ClearRecentSearch ->
+                    clearRecentSearchItem()
+
+                is ExploreSearchAction.Search ->
+                    search(action.keyword)
+
+                is ExploreSearchAction.ClickEditReview ->
+                    _sideEffect.emit(ExploreSearchSideEffect.NavigateToEdit(action.reviewId, action.type))
+
+                ExploreSearchAction.ClearSearchKeyword ->
+                    clearSearchKeyword()
+
+                is ExploreSearchAction.DeleteReview ->
+                    deleteReview(action.reviewId)
+            }
+        }
+    }
+
     private fun getFetchRecentSearchQueries() {
         viewModelScope.launch {
             listOf(
@@ -64,7 +106,7 @@ class ExploreSearchViewModel @Inject constructor(
         }
     }
 
-    fun switchSearchType(
+    private fun switchSearchType(
         searchType: SearchType
     ) {
         searchJob?.cancel()
@@ -78,7 +120,7 @@ class ExploreSearchViewModel @Inject constructor(
         search(_state.value.searchKeyword)
     }
 
-    fun clearSearchKeyword() {
+    private fun clearSearchKeyword() {
         searchJob?.cancel()
         _state.update {
             it.copy(
@@ -169,7 +211,7 @@ class ExploreSearchViewModel @Inject constructor(
         }
     }
 
-    fun removeRecentSearchItem(keyword: String) {
+    private fun removeRecentSearchItem(keyword: String) {
         viewModelScope.launch {
             when (_state.value.searchType) {
                 SearchType.USER -> {
@@ -185,7 +227,7 @@ class ExploreSearchViewModel @Inject constructor(
         }
     }
 
-    fun clearRecentSearchItem() {
+    private fun clearRecentSearchItem() {
         viewModelScope.launch {
             when (_state.value.searchType) {
                 SearchType.USER -> {
@@ -200,7 +242,7 @@ class ExploreSearchViewModel @Inject constructor(
         }
     }
 
-    fun deleteReview(reviewId: Int) {
+    private fun deleteReview(reviewId: Int) {
         viewModelScope.launch {
             postRepository.deletePost(reviewId)
                 .onSuccess {

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/navigation/ExploreSearchNavigation.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/navigation/ExploreSearchNavigation.kt
@@ -1,6 +1,7 @@
 package com.spoony.spoony.presentation.exploreSearch.navigation
 
 import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
@@ -32,13 +33,19 @@ fun NavGraphBuilder.exploreSearchNavGraph(
         enterTransition = {
             slideIntoContainer(
                 AnimatedContentTransitionScope.SlideDirection.Left,
-                animationSpec = tween(500)
+                animationSpec = tween(
+                    durationMillis = 700,
+                    easing = FastOutSlowInEasing
+                )
             )
         },
         exitTransition = {
             slideOutOfContainer(
                 AnimatedContentTransitionScope.SlideDirection.Right,
-                animationSpec = tween(500)
+                animationSpec = tween(
+                    durationMillis = 700,
+                    easing = FastOutSlowInEasing
+                )
             )
         }
     ) {

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/navigation/ExploreSearchNavigation.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/navigation/ExploreSearchNavigation.kt
@@ -3,6 +3,8 @@ package com.spoony.spoony.presentation.exploreSearch.navigation
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -34,19 +36,19 @@ fun NavGraphBuilder.exploreSearchNavGraph(
             slideIntoContainer(
                 AnimatedContentTransitionScope.SlideDirection.Left,
                 animationSpec = tween(
-                    durationMillis = 700,
+                    durationMillis = 500,
                     easing = FastOutSlowInEasing
                 )
-            )
+            ) + fadeIn(animationSpec = tween(500))
         },
         exitTransition = {
             slideOutOfContainer(
                 AnimatedContentTransitionScope.SlideDirection.Right,
                 animationSpec = tween(
-                    durationMillis = 700,
+                    durationMillis = 500,
                     easing = FastOutSlowInEasing
                 )
-            )
+            ) + fadeOut(animationSpec = tween(500))
         }
     ) {
         ExploreSearchRoute(


### PR DESCRIPTION
## Related issue 🛠
- closed #398 

## Work Description ✏️
- 액션 단일화 (ExploreSearchAction 도입)
- 사이드이펙트 분리
- onAction 을 통한 파라미터 단순화
- 탐색 검색 뷰 이동 시 화면 전체 넓이로 설정
- 탐색 검색 뷰 생성 코드 수정

## Screenshot 📸

https://github.com/user-attachments/assets/b65e529c-a1ef-4d99-86aa-448b3bf2637f

## To Reviewers 📢

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 탐색/검색 화면의 사용자 동작을 단일 액션 흐름으로 통합하여 인터랙션 일관성과 예측 가능성을 향상했습니다. 프로필, 마이페이지, 장소 상세, 신고, 편집, 뒤로가기 등 이동 동작이 더 일관되게 동작합니다.
- Style
  - 화면 전환 애니메이션을 가감속 이징과 페이드 인/아웃으로 개선해 전환이 더욱 부드러워졌습니다.
  - 주요 영역에 전체 화면 채움을 적용해 공간 활용을 높이고 화면 구성이 일관되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->