### PR TITLE
[FIX/#402] QA 반영했어요.

### DIFF
--- a/app/src/main/java/com/spoony/spoony/presentation/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/profileedit/ProfileEditScreen.kt
@@ -50,6 +50,7 @@ import com.spoony.spoony.core.designsystem.theme.white
 import com.spoony.spoony.core.designsystem.type.ButtonSize
 import com.spoony.spoony.core.designsystem.type.ButtonStyle
 import com.spoony.spoony.core.util.extension.addFocusCleaner
+import com.spoony.spoony.core.util.extension.noRippleClickable
 import com.spoony.spoony.core.util.extension.toBirthDate
 import com.spoony.spoony.presentation.profileedit.component.ImageHelperBottomSheet
 import com.spoony.spoony.presentation.profileedit.component.ProfileImageList
@@ -125,7 +126,7 @@ fun ProfileEditScreen(
             )
             Icon(
                 imageVector = ImageVector.vectorResource(id = R.drawable.ic_question_24),
-                modifier = Modifier.clickable { isImageBottomSheetVisible = true },
+                modifier = Modifier.noRippleClickable { isImageBottomSheetVisible = true },
                 tint = Color.Unspecified,
                 contentDescription = null
             )

--- a/app/src/main/java/com/spoony/spoony/presentation/profileedit/ProfileEditScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/profileedit/ProfileEditScreen.kt
@@ -2,7 +2,6 @@ package com.spoony.spoony.presentation.profileedit
 
 import BirthSelectButton
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterEndScreen.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterEndScreen.kt
@@ -54,9 +54,9 @@ fun RegisterEndRoute(
     val isNextButtonEnabled = remember(
         state.detailReview,
         state.selectedPhotos,
-        state.isLoading
+        state.isSubmitting
     ) {
-        viewModel.checkSecondStepValidation() && !state.isLoading
+        viewModel.checkSecondStepValidation() && !state.isSubmitting
     }
 
     RegisterEndScreen(

--- a/app/src/main/java/com/spoony/spoony/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/RegisterViewModel.kt
@@ -237,30 +237,36 @@ class RegisterViewModel @Inject constructor(
     }
 
     fun registerPost(onSuccess: () -> Unit) {
+        if (state.value.isSubmitting) return
+
         viewModelScope.launch {
-            _state.update { it.copy(isLoading = true) }
+            _state.update { it.copy(isLoading = true, isSubmitting = true) }
 
             when (registerType) {
                 RegisterType.CREATE -> {
                     repository.registerPost(_state.value.toRegisterPostEntity())
                         .onSuccess {
                             _state.update { it.copy(isLoading = false) }
-                            resetState()
                             onSuccess()
                         }.onLogFailure {
-                            _state.update { it.copy(isLoading = false) }
+                            _state.update { it.copy(isLoading = false, isSubmitting = false) }
                             _sideEffect.emit(RegisterSideEffect.ShowError(ErrorType.UNEXPECTED_ERROR))
                         }
                 }
+
                 RegisterType.EDIT -> {
                     if (postId != null) {
-                        repository.updatePost(_state.value.toUpdatePostEntity(postId, calculateDeleteImageUrls()))
+                        repository.updatePost(
+                            _state.value.toUpdatePostEntity(
+                                postId,
+                                calculateDeleteImageUrls()
+                            )
+                        )
                             .onSuccess {
                                 _state.update { it.copy(isLoading = false) }
-                                resetState()
                                 onSuccess()
                             }.onLogFailure {
-                                _state.update { it.copy(isLoading = false) }
+                                _state.update { it.copy(isLoading = false, isSubmitting = false) }
                                 _sideEffect.emit(RegisterSideEffect.ShowError(ErrorType.UNEXPECTED_ERROR))
                             }
                     }

--- a/app/src/main/java/com/spoony/spoony/presentation/register/model/RegisterState.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/model/RegisterState.kt
@@ -23,6 +23,7 @@ data class RegisterState(
 
     val currentStep: Float = 1f,
     val isLoading: Boolean = false,
+    val isSubmitting: Boolean = false,
     val error: String? = null
 ) {
     companion object {


### PR DESCRIPTION
## Related issue 🛠
- closed #402

## Work Description ✏️
- 리플 제거
- 등록시 State reset 제거
- 중복 클릭 2중 방지

## Screenshot 📸

https://github.com/user-attachments/assets/7387ecf8-66ca-4ba6-8be2-afb7c40c8a3c

## To Reviewers 📢
ASAP하게 수정했습니다ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 회원가입 흐름에서 중복 제출을 방지하고 오류 시 로딩/제출 상태가 정확히 해제되도록 개선
  - Next 버튼 활성화 조건을 제출 중 여부(isSubmitting) 기준으로 조정하여 비정상 동작 최소화

- 스타일
  - 프로필 편집 화면 아이콘 탭 시 물결(ripple) 효과 제거로 터치 피드백을 간결하게 정돈

<!-- end of auto-generated comment: release notes by coderabbit.ai -->