### PR TITLE
[FEAT/#419] 이미지 로딩 뷰를 추가했어요

### DIFF
--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/card/ReviewCard.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/card/ReviewCard.kt
@@ -173,7 +173,8 @@ private fun ImageGrid(
                     .aspectRatio(1f),
                 shape = RoundedCornerShape(imageRadius),
                 contentScale = ContentScale.Crop,
-                contentDescription = null
+                contentDescription = null,
+                showLoadingIndicator = true
             )
         }
     }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
@@ -43,19 +43,24 @@ fun SpoonyImage(
             modifier = modifier.clip(shape),
             loading = {
                 if (showLoadingIndicator) {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        CircularProgressIndicator(
-                            color = SpoonyAndroidTheme.colors.gray300
-                        )
-                    }
+                    LoadingIndicator()
                 }
             },
             success = {
                 SubcomposeAsyncImageContent()
             }
+        )
+    }
+}
+
+@Composable
+private fun LoadingIndicator() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            color = SpoonyAndroidTheme.colors.gray300
         )
     }
 }

--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/image/SpoonyImage.kt
@@ -1,7 +1,11 @@
 package com.spoony.spoony.core.designsystem.component.image
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.RectangleShape
@@ -10,8 +14,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.vectorResource
-import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImageContent
 import com.spoony.spoony.R
+import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 
 @Composable
 fun SpoonyImage(
@@ -19,7 +25,8 @@ fun SpoonyImage(
     modifier: Modifier = Modifier,
     shape: Shape = RectangleShape,
     contentScale: ContentScale = ContentScale.Crop,
-    contentDescription: String? = null
+    contentDescription: String? = null,
+    showLoadingIndicator: Boolean = false
 ) {
     if (LocalInspectionMode.current) {
         Image(
@@ -29,11 +36,26 @@ fun SpoonyImage(
             modifier = modifier.clip(shape)
         )
     } else {
-        AsyncImage(
+        SubcomposeAsyncImage(
             model = model,
             contentDescription = contentDescription,
             contentScale = contentScale,
-            modifier = modifier.clip(shape)
+            modifier = modifier.clip(shape),
+            loading = {
+                if (showLoadingIndicator) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            color = SpoonyAndroidTheme.colors.gray300
+                        )
+                    }
+                }
+            },
+            success = {
+                SubcomposeAsyncImageContent()
+            }
         )
     }
 }

--- a/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/component/ExploreSearchUserItem.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/exploreSearch/component/ExploreSearchUserItem.kt
@@ -42,7 +42,8 @@ fun ExploreSearchUserItem(
             modifier = Modifier.size(48.dp),
             shape = CircleShape,
             contentScale = ContentScale.Crop,
-            contentDescription = null
+            contentDescription = null,
+            showLoadingIndicator = true
         )
         Spacer(modifier = Modifier.width(14.dp))
         Column {

--- a/app/src/main/java/com/spoony/spoony/presentation/gourmet/map/component/MapPlaceDetailCard.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/gourmet/map/component/MapPlaceDetailCard.kt
@@ -67,7 +67,8 @@ fun MapPlaceDetailCard(
                         model = url,
                         modifier = Modifier
                             .height(103.dp)
-                            .weight(1f)
+                            .weight(1f),
+                        showLoadingIndicator = true
                     )
                 }
             }

--- a/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/PlaceDetailImageLazyRow.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/placeDetail/component/PlaceDetailImageLazyRow.kt
@@ -36,7 +36,8 @@ fun PlaceDetailImageLazyRow(
                 model = imageUrl,
                 shape = RoundedCornerShape(10.dp),
                 contentScale = ContentScale.Crop,
-                contentDescription = null
+                contentDescription = null,
+                showLoadingIndicator = true
             )
         }
     }

--- a/app/src/main/java/com/spoony/spoony/presentation/register/component/PhotoPicker.kt
+++ b/app/src/main/java/com/spoony/spoony/presentation/register/component/PhotoPicker.kt
@@ -159,7 +159,8 @@ fun PhotoPicker(
                         model = photo.uri,
                         modifier = Modifier.fillMaxSize(),
                         shape = RoundedCornerShape(8.dp),
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Crop,
+                        showLoadingIndicator = true
                     )
                     Icon(
                         imageVector = ImageVector.vectorResource(id = R.drawable.ic_delete_filled_24),


### PR DESCRIPTION
## Related issue 🛠
- closed #419 

## Work Description ✏️
- 이미지 로딩 뷰를 추가했어요.

## Screenshot 📸
https://github.com/user-attachments/assets/4fefa173-fee4-41aa-9823-4093b859b12c


## To Reviewers 📢
따로 디자인 없고 자체적으로 하기로 했다고 디자인쪽에서 전달 받아서 색상만 회색으로 변경해서 작업했습니다. 다른 곳은 이미지가 빠르게 들어와서 확인하기 어려우실 수 있는데 이미지 업로드 할때는 확인하기 편하더라구요. 위 영상 한번 보시고 좋은 의견 주시면 수정하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 이미지 로딩 인디케이터 추가: 앱 전반의 이미지 컴포넌트에 로딩 표시가 도입되어 이미지 로드 중 원형 진행 표시가 나타납니다.
  * 적용 대상: 사용자 프로필 아바타, 장소 상세 이미지 목록, 지도 장소 상세 카드, 사진 선택기 등 여러 화면에 일괄 적용.
  * UX 개선: 로딩 중 빈 화면이나 깜빡임을 줄여 더 명확한 상태 피드백 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->