### PR TITLE
[FIX/#422] 바텀시트 sheetMaxWidth 기본값 추가

### DIFF
--- a/app/src/main/java/com/spoony/spoony/core/designsystem/component/bottomsheet/SpoonyAdvancedBottomSheet.kt
+++ b/app/src/main/java/com/spoony/spoony/core/designsystem/component/bottomsheet/SpoonyAdvancedBottomSheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import com.spoony.spoony.core.designsystem.theme.SpoonyAndroidTheme
 import com.spoony.spoony.core.designsystem.type.AdvancedSheetState
 import io.morfly.compose.bottomsheet.material3.BottomSheetScaffold
@@ -16,6 +17,7 @@ fun SpoonyAdvancedBottomSheet(
     sheetContent: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     sheetSwipeEnabled: Boolean = true,
+    sheetMaxWidth: Dp = Dp.Infinity,
     dragHandle: @Composable () -> Unit = { SpoonyBasicDragHandle() },
     content: @Composable () -> Unit
 ) {
@@ -27,7 +29,8 @@ fun SpoonyAdvancedBottomSheet(
         sheetSwipeEnabled = sheetSwipeEnabled,
         modifier = modifier,
         sheetContainerColor = SpoonyAndroidTheme.colors.white,
-        sheetDragHandle = dragHandle
+        sheetDragHandle = dragHandle,
+        sheetMaxWidth = sheetMaxWidth
     ) {
         content()
     }


### PR DESCRIPTION
## Related issue 🛠
- closed #422 

## Work Description ✏️
- 바텀시트에 존재하는 sheetMaxWidth 기본값을 Dp.Infinity로 수정

## Screenshot 📸
| as-is | <image src="https://github.com/user-attachments/assets/31ef91ce-11bb-4948-9a97-5a7c98bf54a0" width=700>  |
|-------|-------|
| **to-be** | <image src="https://github.com/user-attachments/assets/ef713a16-c2ad-4fb1-9b59-7d599f50b9b3" width=700>  |

## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
오 이건 파라미터 뚫려있어서 생각보다 엄청 간단하게 해결했네요ㅎㅎ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 하단 시트 컴포넌트의 최대 너비를 조정할 수 있는 새로운 옵션이 추가되었습니다. 기본값은 제한 없음으로 설정되어 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->